### PR TITLE
Recover faster from silent MQTT outages

### DIFF
--- a/custom_components/navimow/__init__.py
+++ b/custom_components/navimow/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     CLIENT_SECRET,
     API_BASE_URL,
     MQTT_BROKER,
+    MQTT_KEEPALIVE_SECONDS,
     MQTT_PORT,
     MQTT_USERNAME,
     MQTT_PASSWORD,
@@ -323,7 +324,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 loop=hass.loop,
                 records=devices,
                 # broker 每小时断连时，优先用 MQTT 协议层 keepalive（PINGREQ/PINGRESP）保活。
-                keepalive_seconds=2400,  # 40 分钟
+                # 较短的 keepalive 可更快检测半开连接（见 segwaynavimow/NavimowHA#37）。
+                keepalive_seconds=MQTT_KEEPALIVE_SECONDS,
                 reconnect_min_delay=1,
                 reconnect_max_delay=60,
             )

--- a/custom_components/navimow/const.py
+++ b/custom_components/navimow/const.py
@@ -35,10 +35,13 @@ MQTT_PASSWORD: Final | None = None
 UPDATE_INTERVAL: Final = 30
 
 # MQTT 超时时间（秒），超过该时间未收到消息则走 HTTP 兜底
-MQTT_STALE_SECONDS: Final = 300
+MQTT_STALE_SECONDS: Final = 90
 
 # HTTP 兜底最小拉取间隔（秒），避免频繁请求
-HTTP_FALLBACK_MIN_INTERVAL: Final = 3600
+HTTP_FALLBACK_MIN_INTERVAL: Final = 60
+
+# MQTT 协议层 keepalive（秒），用于检测半开连接
+MQTT_KEEPALIVE_SECONDS: Final = 120
 
 # MowerStatus 到 LawnMowerActivity 的映射
 MOWER_STATUS_TO_ACTIVITY = {

--- a/custom_components/navimow/coordinator.py
+++ b/custom_components/navimow/coordinator.py
@@ -152,12 +152,22 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._last_http_fetch is None
             or now - self._last_http_fetch > HTTP_FALLBACK_MIN_INTERVAL
         )
+        if is_mqtt_stale and not self.sdk.is_connected:
+            _LOGGER.warning(
+                "MQTT appears disconnected for device %s; relying on HTTP fallback",
+                self.device.id,
+            )
         if is_mqtt_stale and can_http_fetch:
             try:
                 status = await self.api.async_get_device_status(self.device.id)
                 self._last_state = self._device_status_to_state(status)
                 self._last_http_fetch = now
                 self._last_data_source = "http_fallback"
+                _LOGGER.info(
+                    "HTTP fallback succeeded for device %s (MQTT stale)",
+                    self.device.id,
+                )
+                self.async_set_updated_data(self._build_data())
             except ConfigEntryAuthFailed:
                 raise
             except Exception as err:


### PR DESCRIPTION
First off, thanks for building and sharing NavimowHA. It has been fantastic to have proper Home Assistant integration for the mower, and the work you have put into it is much appreciated.

This PR attempts to address #37, where the mower entity state in Home Assistant goes stale (and often stays stale for hours) even though the mower is online and the Segway app shows current data.

## Why

The integration relies on MQTT for live updates and falls back to HTTP polling when MQTT data looks stale. In practice I was seeing long silent MQTT outages where:

- The MQTT client believed it was still connected, so no reconnect was triggered.
- The staleness threshold was long enough (5 minutes) that HA entities looked frozen for a noticeable time before anything kicked in.
- Once the fallback did engage, it only polled once an hour, so state stayed stale until the next poll or an MQTT message happened to arrive.
- There was no log signal that the integration was limping along on HTTP rather than MQTT, which made it hard to tell what was going on from the HA logs.

The net effect from a user's perspective was "the integration is broken" even though nothing was logging errors.

## How

The change keeps the existing MQTT-first, HTTP-fallback design and just tightens the timings and visibility around it:

- Shorten the MQTT staleness window from 300s to 90s so the fallback engages sooner.
- While MQTT is considered stale, poll the HTTP fallback every 60s instead of every 3600s so state actually refreshes.
- Drop the MQTT keepalive from 2400s to 120s so half-open TCP connections are detected and reconnected much faster.
- Log at INFO when the HTTP fallback is actively covering for MQTT, and WARN when the SDK reports MQTT disconnected, so these conditions are visible in the HA log.
- Push fallback data to listeners immediately via `async_set_updated_data` so entities update as soon as a fallback poll completes rather than waiting for the next coordinator tick.

No config options or entity shapes change, and the fallback behavior is still a fallback. It just recovers in roughly a minute instead of an hour or more.

Totally understand if the direction or specific numbers are not what you want. Happy to adjust, split this up, or make any of the intervals configurable if that is preferable. Thanks again for the project.

Fixes #37 