### PR TITLE
fix(navimow): treat MQTT user-info circuit-breaker as non-fatal

### DIFF
--- a/custom_components/navimow/__init__.py
+++ b/custom_components/navimow/__init__.py
@@ -126,9 +126,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # 获取 MQTT 连接信息并创建 SDK
         try:
             mqtt_info = await api.async_get_mqtt_user_info()
+            # Cache credentials in entry.data so they survive transient API outages
+            _cached = {
+                "cached_mqtt_host": mqtt_info.get("mqttHost"),
+                "cached_mqtt_url": mqtt_info.get("mqttUrl"),
+                "cached_mqtt_username": mqtt_info.get("userName"),
+                "cached_mqtt_password": mqtt_info.get("pwdInfo"),
+            }
+            hass.config_entries.async_update_entry(entry, data={**entry.data, **_cached})
         except MowerAPIError as err:
-            _LOGGER.error("Failed to get MQTT info: %s", err)
-            raise ConfigEntryNotReady(f"Failed to get MQTT info: {err}") from err
+            # The Segway API applies a circuit-breaker pattern on this endpoint.
+            # Repeated HA retries (ConfigEntryNotReady every ~80 s) keep the
+            # breaker open indefinitely.  Treat the failure as non-fatal:
+            # fall back to credentials cached from a previous successful call,
+            # or to the hardcoded defaults.  The coordinator's hourly HTTP
+            # fallback will keep the entity available even without MQTT.
+            _LOGGER.warning(
+                "Failed to get MQTT user info (%s) — falling back to cached/default "
+                "MQTT config. Real-time MQTT updates may be unavailable until the "
+                "Segway API recovers.",
+                err,
+            )
+            mqtt_info = {
+                "mqttHost": entry.data.get("cached_mqtt_host"),
+                "mqttUrl": entry.data.get("cached_mqtt_url"),
+                "userName": entry.data.get("cached_mqtt_username"),
+                "pwdInfo": entry.data.get("cached_mqtt_password"),
+            }
 
         mqtt_host = mqtt_info.get("mqttHost") or entry.data.get(
             "mqtt_broker", MQTT_BROKER


### PR DESCRIPTION
## Problem

When the Segway API circuit-breaker trips on `/openapi/mqtt/userInfo/get/v2`, the integration raises `ConfigEntryNotReady`. Home Assistant then retries setup every ~80 seconds — each retry re-trips the breaker, so the integration **never recovers** on its own.

Reported in #49 (today, 2026-04-16). Multiple users are affected.

## Root cause

```python
# __init__.py line 128-131 (current)
mqtt_info = await api.async_get_mqtt_user_info()
except MowerAPIError as err:
    _LOGGER.error("Failed to get MQTT info: %s", err)
    raise ConfigEntryNotReady(f"Failed to get MQTT info: {err}") from err
```

The error is fatal, but it doesn't need to be: the coordinator already has an hourly HTTP fallback (`HTTP_FALLBACK_MIN_INTERVAL = 3600`), and the MQTT broker address/credentials can be cached from a previous successful call.

## Fix

- **On success**: cache MQTT credentials (`host`, `url`, `username`, `password`) in `entry.data` so they survive future outages.
- **On `MowerAPIError`**: log a `WARNING` (not `ERROR`) and fall back to cached credentials, or hardcoded defaults if no cache exists yet.
- The integration loads normally; the coordinator's HTTP fallback keeps the entity available without real-time MQTT.

Once the Segway API recovers, the next HA restart will successfully fetch and cache fresh credentials — no user action needed.

## Test

Verified locally with a live installation that was stuck in the retry loop. After this fix:
- `WARNING` is logged instead of `ERROR`
- The integration loads successfully
- HTTP fallback polls the device status every hour