### PR TITLE
Fix stale entity state during docked/charging mode

### DIFF
--- a/custom_components/navimow/__init__.py
+++ b/custom_components/navimow/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     MQTT_PORT,
     MQTT_USERNAME,
     MQTT_PASSWORD,
+    MQTT_KEEPALIVE_SECONDS,
 )
 from .services import async_setup_services
 
@@ -322,8 +323,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 auth_headers=auth_headers,
                 loop=hass.loop,
                 records=devices,
-                # broker 每小时断连时，优先用 MQTT 协议层 keepalive（PINGREQ/PINGRESP）保活。
-                keepalive_seconds=2400,  # 40 分钟
+                keepalive_seconds=MQTT_KEEPALIVE_SECONDS,
                 reconnect_min_delay=1,
                 reconnect_max_delay=60,
             )

--- a/custom_components/navimow/const.py
+++ b/custom_components/navimow/const.py
@@ -34,11 +34,16 @@ MQTT_PASSWORD: Final | None = None
 # 更新间隔（秒）
 UPDATE_INTERVAL: Final = 30
 
-# MQTT 超时时间（秒），超过该时间未收到消息则走 HTTP 兜底
-MQTT_STALE_SECONDS: Final = 300
+# MQTT 超时时间（秒），超过该时间未收到状态消息则走 HTTP 兜底。
+# Reduced to detect silent MQTT outages (no state pushes from server) sooner.
+MQTT_STALE_SECONDS: Final = 90
 
-# HTTP 兜底最小拉取间隔（秒），避免频繁请求
-HTTP_FALLBACK_MIN_INTERVAL: Final = 3600
+# MQTT Keepalive (seconds). PINGREQ interval for faster half-open TCP detection.
+MQTT_KEEPALIVE_SECONDS: Final = 120
+
+# HTTP 兜底最小拉取间隔（秒）。
+# 当 MQTT 实时状态缺失时，按分钟级回退到 HTTP，避免状态长时间卡住。
+HTTP_FALLBACK_MIN_INTERVAL: Final = 60
 
 # MowerStatus 到 LawnMowerActivity 的映射
 MOWER_STATUS_TO_ACTIVITY = {

--- a/custom_components/navimow/coordinator.py
+++ b/custom_components/navimow/coordinator.py
@@ -53,6 +53,7 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_state: DeviceStateMessage | None = None
         self._last_attributes: DeviceAttributesMessage | None = None
         self._last_mqtt_update: float | None = None
+        self._last_mqtt_state_update: float | None = None
         self._last_http_fetch: float | None = None
         self._last_data_source: str | None = None
 
@@ -69,6 +70,7 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "meta": {
                 "last_data_source": self._last_data_source,
                 "last_mqtt_update_monotonic": self._last_mqtt_update,
+                "last_mqtt_state_update_monotonic": self._last_mqtt_state_update,
                 "last_http_fetch_monotonic": self._last_http_fetch,
             },
         }
@@ -144,20 +146,33 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._last_attributes = cached_attrs
 
         now = time.monotonic()
-        is_mqtt_stale = (
-            self._last_mqtt_update is None
-            or now - self._last_mqtt_update > MQTT_STALE_SECONDS
+        # Use state-specific freshness here. Attributes packets can still arrive
+        # while mower activity/state is stale, which would otherwise suppress
+        # the HTTP fallback and leave Home Assistant showing old status.
+        is_state_stale = (
+            self._last_mqtt_state_update is None
+            or now - self._last_mqtt_state_update > MQTT_STALE_SECONDS
         )
         can_http_fetch = (
             self._last_http_fetch is None
             or now - self._last_http_fetch > HTTP_FALLBACK_MIN_INTERVAL
         )
-        if is_mqtt_stale and can_http_fetch:
+        if is_state_stale and can_http_fetch:
             try:
                 status = await self.api.async_get_device_status(self.device.id)
+                _LOGGER.debug(
+                    "HTTP fallback success: device=%s battery=%s status=%s",
+                    self.device.id,
+                    status.battery,
+                    status.status.value if status.status else "unknown",
+                )
                 self._last_state = self._device_status_to_state(status)
                 self._last_http_fetch = now
                 self._last_data_source = "http_fallback"
+                # Push immediately so entities update without waiting for the
+                # next coordinator tick.
+                self.data = self._build_data()
+                self.async_set_updated_data(self.data)
             except ConfigEntryAuthFailed:
                 raise
             except Exception as err:
@@ -166,10 +181,11 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
         _LOGGER.debug(
-            "Coordinator update: device=%s source=%s mqtt_ts=%s http_ts=%s",
+            "Coordinator update: device=%s source=%s mqtt_ts=%s mqtt_state_ts=%s http_ts=%s",
             self.device.id,
             self._last_data_source,
             self._last_mqtt_update,
+            self._last_mqtt_state_update,
             self._last_http_fetch,
         )
         self.data = self._build_data()
@@ -184,7 +200,9 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             state.state,
             state.battery,
         )
-        self._last_mqtt_update = time.monotonic()
+        now = time.monotonic()
+        self._last_mqtt_update = now
+        self._last_mqtt_state_update = now
         self._last_data_source = "mqtt_push"
         self.hass.loop.call_soon_threadsafe(self._update_from_state, state)
 
@@ -192,9 +210,8 @@ class NavimowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if attrs.device_id != self.device.id:
             return
         _LOGGER.debug(
-            "MQTT attributes received: device=%s keys=%d",
+            "MQTT attributes received: device=%s",
             attrs.device_id,
-            len(getattr(attrs, "__dict__", {}) or {}),
         )
         self._last_mqtt_update = time.monotonic()
         self.hass.loop.call_soon_threadsafe(self._update_from_attributes, attrs)


### PR DESCRIPTION
## Summary
Fixes entities staying at stale values for hours when the mower is docked or charging, even though the mower is online and the Navimow app shows current data.
## Changes
- **Reduce MQTT staleness threshold** from 300s to 90s so the HTTP fallback activates sooner
- **Reduce HTTP fallback polling interval** from 3600s to 60s so state data refreshes within a minute
- **Reduce MQTT keepalive** from 2400s to 120s for faster detection of half-open TCP connections
- **Separate state freshness from attribute activity** — the HTTP fallback is now triggered by stale *state* data, not stale *general* MQTT activity. This ensures updates continue even when the server only sends attribute packets (no state)
- **Push fallback results immediately** to entity listeners via `async_set_updated_data` instead of waiting for the next coordinator tick
## Root Cause
When the mower is docked or charging, the Navimow server stops sending MQTT state messages. Only attribute packets continue to arrive. The original staleness check used a single timestamp updated by *all* MQTT messages, so incoming attribute traffic kept resetting the timer and suppressed the HTTP fallback. Battery and activity data remained frozen until the next rare state push or a restart.
The fix tracks state freshness independently, so the HTTP fallback engages based on state staleness alone, regardless of attribute traffic.
## Testing
- Docked/charging: state updates every ~60s via HTTP fallback
- Mowing: state updates instantly via MQTT push
- No config changes required, no breaking changes